### PR TITLE
pawoo以外でエラーが起きるのを修正

### DIFF
--- a/src/mastoinker/timeline.js
+++ b/src/mastoinker/timeline.js
@@ -165,7 +165,8 @@ TimelineObserver.prototype.handleStatus = function (node) {
     return icon.parentNode;
   }
   
-  var statusLink = node.querySelector('a.status__time');
+  var statusLink = node.querySelector('a.status__relative-time');
+  if (statusLink == null) statusLink = node.querySelector('a.status__time'); // for pawoo.net
   var boostButton = findBoostButton(node);
   var favouriteButton = findFavButton(node);
 
@@ -260,6 +261,7 @@ TimelineObserver.prototype.handleRemoval = function (node) {
 
 TimelineObserver.prototype.handleStatusRemoval = function (node) {
   var statusLink = node.querySelector('a.status__relative-time');
+  if (statusLink == null) statusLink = node.querySelector('a.status__time'); // for pawoo.net
   if (statusLink == null) return;
 
   var id = statusLink.pathname;


### PR DESCRIPTION
pawooは'a.status__time'ですが、それ以外(mstdn.jp, mastodon.cloud)では'a.status__relative-time'のままなので
statusLinkがnullになり、その後のstatusLink.pathnameでエラーが発生します。

pawooが特殊なのだと思われるので、一旦'a.status__relative-time'を取得してみて、失敗したら'a.status__time'を取得するように変更しました。